### PR TITLE
Sed not found

### DIFF
--- a/src/gwf_failed_targets/slurm.py
+++ b/src/gwf_failed_targets/slurm.py
@@ -19,6 +19,7 @@ OOM_REGEX = r"error: Detected [0-9]+ oom_kill events? in StepId=[0-9]+.batch. So
 FS_LIST = [
     "Device or resource busy",
     "sed: No such file or directory",
+    "python: No such file or directory",
 ]
 
 

--- a/src/gwf_failed_targets/slurm.py
+++ b/src/gwf_failed_targets/slurm.py
@@ -114,7 +114,7 @@ class SlurmAccounting:
             return FailureType.Timeout
         elif re.search(pattern=OOM_REGEX, string=log):
             return FailureType.OutOfMemory
-        elif "sbatch: error: Batch job submission failed" in log:
+        elif "error: Batch job submission failed" in log:
             return FailureType.Submission
         elif any(s in log for s in FS_LIST):
             return FailureType.FileSystem

--- a/src/gwf_failed_targets/slurm.py
+++ b/src/gwf_failed_targets/slurm.py
@@ -16,6 +16,10 @@ from .utilities import FailureType, tail
 
 TIMEOUT_REGEX = r"error: \*\*\* JOB [0-9]+ ON [a-zA-Z0-9_-]+ CANCELLED AT [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} DUE TO TIME LIMIT \*\*\*"
 OOM_REGEX = r"error: Detected [0-9]+ oom_kill events? in StepId=[0-9]+.batch. Some of the step tasks have been OOM Killed."
+FS_LIST = [
+    "Device or resource busy",
+    "sed: No such file or directory",
+]
 
 
 @dataclass
@@ -112,7 +116,7 @@ class SlurmAccounting:
             return FailureType.OutOfMemory
         elif "sbatch: error: Batch job submission failed" in log:
             return FailureType.Submission
-        elif "Device or resource busy" in log:
+        elif any(s in log for s in FS_LIST):
             return FailureType.FileSystem
         return FailureType.Unknown
 


### PR DESCRIPTION
We've identified `sed not found` as a rather common file system error. String matching will now correctly identify it as a file system error.

Solves #2.